### PR TITLE
feat: Switch to External Secrets Operator

### DIFF
--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   # - namespace.yaml
   # - resource-quota.yaml
   # - limit-range.yaml
-  # - secret.yaml
+  - secret.yaml
   - application.yaml

--- a/kubernetes/base/secret.yaml
+++ b/kubernetes/base/secret.yaml
@@ -1,15 +1,79 @@
-apiVersion: v1
-kind: Secret
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: env
+#   namespace: analytics-for-spotify
+#   labels:
+#     app.kubernetes.io/instance: analytics-for-spotify_analytics-for-spotify
+# stringData:
+#   CLIENT_ID: "<path:secret/data/spotify/spotify#client_id>"
+#   CLIENT_SECRET: "<path:secret/data/spotify/spotify#client_secret>"
+#   DB_HOST: "<path:secret/data/spotify/database#db_host>"
+#   DATABASE: "<path:secret/data/spotify/database#database>"
+#   DB_USER: "<path:secret/data/spotify/database#db_user>"
+#   DB_PASSWORD: "<path:secret/data/spotify/database#db_password>"
+#   REDIRECT_URL: "<path:secret/data/spotify/spotify#redirect_url>"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
 metadata:
-  name: env
+  name: vault
   namespace: analytics-for-spotify
   labels:
     app.kubernetes.io/instance: analytics-for-spotify_analytics-for-spotify
-stringData:
-  CLIENT_ID: "<path:secret/data/spotify/spotify#client_id>"
-  CLIENT_SECRET: "<path:secret/data/spotify/spotify#client_secret>"
-  DB_HOST: "<path:secret/data/spotify/database#db_host>"
-  DATABASE: "<path:secret/data/spotify/database#database>"
-  DB_USER: "<path:secret/data/spotify/database#db_user>"
-  DB_PASSWORD: "<path:secret/data/spotify/database#db_password>"
-  REDIRECT_URL: "<path:secret/data/spotify/spotify#redirect_url>"
+spec:
+  provider:
+    vault:
+      server: "https://vault.arthurvardevanyan.com"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "analytics-for-spotify"
+          role: "analytics-for-spotify"
+          serviceAccountRef:
+            name: "pipeline"
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: analytics-for-spotify
+  namespace: analytics-for-spotify
+  labels:
+    app.kubernetes.io/instance: analytics-for-spotify_analytics-for-spotify
+spec:
+  refreshInterval: "1h"
+  secretStoreRef:
+    name: vault
+    kind: SecretStore
+  target:
+    name: env
+  data:
+    - secretKey: CLIENT_ID
+      remoteRef:
+        key: spotify/spotify
+        property: client_id
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: spotify/spotify
+        property: client_secret
+    - secretKey: DB_HOST
+      remoteRef:
+        key: spotify/database
+        property: db_host
+    - secretKey: DATABASE
+      remoteRef:
+        key: spotify/database
+        property: database
+    - secretKey: DB_USER
+      remoteRef:
+        key: spotify/database
+        property: db_user
+    - secretKey: DB_PASSWORD
+      remoteRef:
+        key: spotify/database
+        property: db_password
+    - secretKey: REDIRECT_URL
+      remoteRef:
+        key: spotify/spotify
+        property: redirect_url


### PR DESCRIPTION
Since Using a "Multi-Tenant" ArgoCD Instance, ArgoCD Vault Plugin is not present.  Switching to External Secrets Operator for managing External Secrets 